### PR TITLE
更改前端使用的ws库

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-virtualized": "^9.22.3",
     "react-window": "^1.8.6",
     "simplebar": "5.3.6",
-    "simplebar-react": "2.3.6"
+    "simplebar-react": "2.3.6",
+    "socket.io-client": "^4.4.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "12.0.4",

--- a/src/components/container/AppContainer/WebSocketContainer/index.tsx
+++ b/src/components/container/AppContainer/WebSocketContainer/index.tsx
@@ -1,54 +1,47 @@
-import { useEffect } from 'react';
-import useWebSocket, { ReadyState } from 'react-use-websocket';
-
+import { io } from 'socket.io-client';
 import { useGameLog, useGameState } from '~/data';
+// import { loadScreenCap } from '~/components/main/Screen';
 
 const WebSocketContainer = () => {
   const [gameLog, setGameLog] = useGameLog();
   const [, setGameState] = useGameState();
 
-  const socketUrl = `ws://127.0.0.1:8765/`;
+  var socket = io();
 
-  const { lastMessage, readyState } = useWebSocket(socketUrl, {
-    reconnectAttempts: Infinity,
-    reconnectInterval: 1000 * 10,
+  socket.on('connect', function() {
+    fetch('/getState')
+      .then((res) => res.json())
+      .then((res) => {
+        setGameState(res);
+      });
   });
 
-  useEffect(() => {
-    if (readyState === ReadyState.OPEN) {
-      fetch('/getState')
-        .then((res) => res.json())
-        .then((res) => {
-          setGameState(res);
-        });
-    }
-  }, [readyState]);
+  socket.on('onStateUpdate', function(data:any) {
+    setGameState(data);
+  });
 
-  useEffect(() => {
-    if (lastMessage) {
-      const reader = new FileReader();
+  socket.on('onLogUpdate', function(log:any) {
+    setGameLog([[log.time, log.data], ...(gameLog || [])]);
+  });
 
-      reader.onload = (e) => {
-        if (e.target && e.target.readyState === 2) {
-          const enc = new TextDecoder('utf-8');
+  // socket.on(
+  //   'onFrameUpdate',
+  //   function(data){
+    // const img = new Image();
 
-          const res = JSON.parse(
-            enc.decode(new Uint8Array(e.target.result as ArrayBuffer))
-          );
+    // img.src = "data:image/png;base64," + data
+    // img.onload = () => {
+    //   canvas.width = img.width;
+    //   canvas.height = img.height;
 
-          if (res.type === 'update-state') {
-            setGameState(res.data);
-          }
+    //   if (ctx) {
+    //     ctx.drawImage(img, 0, 0);
+    //   }
 
-          if (res.type === 'push-log-message') {
-            setGameLog([[res.time, res.data], ...(gameLog || [])]);
-          }
-        }
-      };
-
-      reader.readAsArrayBuffer(lastMessage.data);
-    }
-  }, [lastMessage]);
+    //   img.remove();
+    // };
+  //   }
+  // )
 
   return null;
 };


### PR DESCRIPTION
生硬地替换了前端使用的websocket库，使用了socket.io-client来和flask-socketio更好的配合，使用起来也更加方便，由于不太会写前端目前没有完成实时更新截图的功能，配套后端在WFHelper的dev分支中